### PR TITLE
git-release-notes is failing pushing onto undefined

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -36,16 +36,19 @@ function processCommits (commitMessages, options) {
 	var workingCommit;
 	stream.forEach(function (rawLine) {
 		var line = parseLine(rawLine);
-                if (!workingCommit) {
-                        //  We can see a message before a new so we need to
-                        //  do it outside of either of those cases.
+		if (line.type === "new") {
 			workingCommit = {
 				messageLines : []
 			};
-                }
-		if (line.type === "new") {
 			commits.push(workingCommit);
 		} else if (line.type === "message") {
+                        if (!workingCommit) {
+                                //  We can see a message before a new so we need to
+                                //  initialize workingCommit here.
+                                workingCommit = {
+                                        messageLines : []
+                                };
+                        }
 			workingCommit.messageLines.push(line.message);
 		} else if (line.type === "title") {
 			var title = parseTitle(line.message, options);

--- a/lib/git.js
+++ b/lib/git.js
@@ -36,10 +36,14 @@ function processCommits (commitMessages, options) {
 	var workingCommit;
 	stream.forEach(function (rawLine) {
 		var line = parseLine(rawLine);
-		if (line.type === "new") {
+                if (!workingCommit) {
+                        //  We can see a message before a new so we need to
+                        //  do it outside of either of those cases.
 			workingCommit = {
 				messageLines : []
 			};
+                }
+		if (line.type === "new") {
 			commits.push(workingCommit);
 		} else if (line.type === "message") {
 			workingCommit.messageLines.push(line.message);


### PR DESCRIPTION
When walking a list of commits we end up getting a message of type
"message" before one of type "new".  We setup the array of lines when we
get a message of type "new".  We need to initialize that when we see the
first line of the message instead.
